### PR TITLE
[FIX] stock_picking_putaway_recompute: Harmonize computations and fix…

### DIFF
--- a/stock_picking_putaway_recompute/models/stock_move_line.py
+++ b/stock_picking_putaway_recompute/models/stock_move_line.py
@@ -16,12 +16,16 @@ class StockMoveLine(models.Model):
     )
 
     @api.depends(
-        "picking_type_id.allow_to_recompute_putaways", "picking_id.printed", "qty_done"
+        "picking_type_id.allow_to_recompute_putaways", "picking_id.printed", "picking_id.state", "result_package_id", "qty_done"
     )
     def _compute_can_recompute_putaways(self):
         can_recompute_lines = self._filtered_for_putaway_recompute()
         can_recompute_lines.can_recompute_putaways = True
         (self - can_recompute_lines).can_recompute_putaways = False
+
+    def _can_recompute_putaway(self):
+        self.ensure_one()
+        return self.picking_id._can_recompute_putaway() and not self.result_package_id and not self.qty_done
 
     def _filtered_for_putaway_recompute(self) -> Self:
         """
@@ -31,12 +35,7 @@ class StockMoveLine(models.Model):
             - have their picking not printed (started)
             - have their qty_done field != 0
         """
-        return self.filtered(
-            lambda line: line.picking_type_id.allow_to_recompute_putaways
-            and not line.picking_id.printed
-            and not line.result_package_id
-            and not line.qty_done
-        )
+        return self.filtered(lambda line: line._can_recompute_putaway())
 
     def _recompute_putaways(self) -> None:
         """

--- a/stock_picking_putaway_recompute/models/stock_picking.py
+++ b/stock_picking_putaway_recompute/models/stock_picking.py
@@ -23,15 +23,17 @@ class StockPicking(models.Model):
         for picking in self:
             picking.move_line_ids._recompute_putaways()
 
+    def _can_recompute_putaway(self):
+        self.ensure_one()
+        return self.picking_type_id.allow_to_recompute_putaways and self.state == "assigned" and not self.printed
+
     def _filtered_can_recompute_putaways(self) -> Self:
         """
         Filter current recordset in order to get the pickings that can
         """
-        return self.filtered(
-            lambda picking: picking.state == "assigned" and not picking.printed
-        )
+        return self.filtered(lambda pick: pick._can_recompute_putaway())
 
-    @api.depends("state", "printed")
+    @api.depends("picking_type_id.allow_to_recompute_putaways", "state", "printed")
     def _compute_can_recompute_putaways(self):
         can_recompute_pickings = self._filtered_can_recompute_putaways()
         can_recompute_pickings.can_recompute_putaways = True


### PR DESCRIPTION
… dependencies

Recomputation was allowed at picking level even if it was not allowed on the picking type.
Make sure the computation on stock.move.line reuses the conditions defined at picking level.